### PR TITLE
Execute post_context_change hook

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -528,6 +528,13 @@ class BlenderEngine(Engine):
             if old_context != new_context:
                 self.create_shotgun_menu()
 
+        self.execute_hook_method(
+            tank.platform.constants.CONTEXT_CHANGE_HOOK,
+            "post_context_change",
+            previous_context=old_context,
+            current_context=new_context
+        )
+
     def _run_app_instance_commands(self):
         """
         Runs the series of app instance commands listed in the

--- a/info.yml
+++ b/info.yml
@@ -25,6 +25,13 @@ configuration:
                      context every time the currently loaded file changes. Defaults to True."
         default_value: True
 
+    context_change:
+        type: hook
+        parameters: []
+        description: Triggered on context change, e.g. project to shot_step
+        allows_empty: True
+        default_value: None
+
     compatibility_dialog_min_version:
         type: int
         description: "Specify the minimum Application major version that will prompt a warning if


### PR DESCRIPTION
Figured out engines were themselves responsible for firing `post_context_change`.