### PR TITLE
Fix #7 by refactoring startup.py

### DIFF
--- a/blender_software_info.py
+++ b/blender_software_info.py
@@ -1,0 +1,52 @@
+'''
+blender_software_info
+---------------------
+
+This module can be executed using the blender executables --python arg like so:
+
+blender --background --python blender_software_info.py
+
+It outputs json to stdout containing info about the blender install. Here is
+a minimal example that calls blender_software_info.py and extracts the json
+data using Python's regex module.
+
+:: python
+
+    import json
+    import re
+    import subprocess
+
+    try:
+        output = subprocess.check_output(
+            'blender --background --python blender_software_info.py',
+            stderr=subprocess.STDOUT,
+            shell=True,
+            universal_newlines=True,
+        )
+        match = re.search(r'<json>(.*)</json>', output)
+        software_info = json.loads(match.group(1))
+        print('Blender Software Info:')
+        print('    version: ' + software_info['version'])
+        print('    user_scripts: ' + software_info['user_scripts'])
+    except subprocess.CalledProcessError as e:
+        print('Failed to get software info from blender executable: %s' % e)
+
+This script is used in tk-blender's startup.py to find the appropriate
+BLENDER_USER_SCRIPTS directory in BlenderLauncher._install_shotgun_menu_py.
+'''
+
+import json
+import bpy.app
+import bpy.utils
+
+
+def main():
+    software_info = json.dumps({
+        'version': bpy.app.version_string,
+        'user_scripts': bpy.utils.script_path_user(),
+    })
+    print(f'<json>{software_info}</json>')
+
+
+if __name__ == '__main__':
+    main()

--- a/resources/scripts/startup/Shotgun_menu.py
+++ b/resources/scripts/startup/Shotgun_menu.py
@@ -13,7 +13,7 @@
 
 import os
 import sys
-import imp
+import importlib.machinery
 import time
 import ast
 import inspect
@@ -250,7 +250,10 @@ def boostrap():
         sys.path.insert(0, SGTK_MODULE_PATH)
 
     engine_startup_path = os.environ.get("SGTK_BLENDER_ENGINE_STARTUP")
-    engine_startup = imp.load_source("sgtk_blender_engine_startup", engine_startup_path)
+    engine_startup = importlib.machinery.SourceFileLoader(
+        "sgtk_blender_engine_startup",
+        engine_startup_path,
+    ).load_module()
 
     # Fire up Toolkit and the environment engine.
     engine_startup.start_toolkit()


### PR DESCRIPTION
Rather than setting BLENDER_USER_SCRIPTS in startup.py, this PR copies Shotgun_menu.py file to a users existing BLENDER_USER_SCRIPTS/startup directory. This allows users to continue using their existing BLENDER_USER_SCRIPTS directory to install custom addons and modules as they need them.

For our studio we already were setting BLENDER_USER_SCRIPTS to a shared network path, so this PR allows us to continue doing that. I'm hoping one day Blender will allow multiple paths to be set but for now this is the best alternative I could come up with.