### PR TITLE
Remove renderable_only flag

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_session_geometry.py
+++ b/hooks/tk-multi-publish2/basic/publish_session_geometry.py
@@ -281,7 +281,6 @@ class BlenderSessionGeometryPublishPlugin(HookBaseClass):
                 context,
                 filepath=publish_path,
                 selected=False,
-                renderable_only=True,
                 uvs=True,
                 face_sets=True,
                 start=start_frame,


### PR DESCRIPTION
# Problem

This flag [disappeared in Blender 2.93](https://docs.blender.org/api/2.93/bpy.ops.wm.html), effectively breaking the geometry publish. 

# Solution

Remove this flag. Change should not affect earlier versions of Blender as it is set to its default value.
