### PR TITLE
Alembic export compatible with Blender 3

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_session_geometry.py
+++ b/hooks/tk-multi-publish2/basic/publish_session_geometry.py
@@ -281,7 +281,7 @@ class BlenderSessionGeometryPublishPlugin(HookBaseClass):
                 context,
                 filepath=publish_path,
                 selected=False,
-                renderable_only=True,
+                visible_objects_only=True,
                 uvs=True,
                 face_sets=True,
                 start=start_frame,

--- a/hooks/tk-multi-publish2/basic/publish_session_geometry.py
+++ b/hooks/tk-multi-publish2/basic/publish_session_geometry.py
@@ -276,9 +276,8 @@ class BlenderSessionGeometryPublishPlugin(HookBaseClass):
 
         try:
             context = get_view3d_operator_context()
-
             version = bpy.app.version_string
-            if version[:2]) == '2.':
+            if version[:2] == '2.':
                 bpy.ops.wm.alembic_export(
                     context,
                     filepath=publish_path,
@@ -289,7 +288,7 @@ class BlenderSessionGeometryPublishPlugin(HookBaseClass):
                     start=start_frame,
                     end=end_frame,
                 )
-            if version[:2]) == '3.':
+            if version[:2] == '3.':
                 bpy.ops.wm.alembic_export(
                     context,
                     filepath=publish_path,

--- a/hooks/tk-multi-publish2/basic/publish_session_geometry.py
+++ b/hooks/tk-multi-publish2/basic/publish_session_geometry.py
@@ -277,16 +277,30 @@ class BlenderSessionGeometryPublishPlugin(HookBaseClass):
         try:
             context = get_view3d_operator_context()
 
-            bpy.ops.wm.alembic_export(
-                context,
-                filepath=publish_path,
-                selected=False,
-                visible_objects_only=True,
-                uvs=True,
-                face_sets=True,
-                start=start_frame,
-                end=end_frame,
-            )
+            version = bpy.app.version_string
+            if version[:2]) == '2.':
+                bpy.ops.wm.alembic_export(
+                    context,
+                    filepath=publish_path,
+                    selected=False,
+                    renderable_only=True,
+                    uvs=True,
+                    face_sets=True,
+                    start=start_frame,
+                    end=end_frame,
+                )
+            if version[:2]) == '3.':
+                bpy.ops.wm.alembic_export(
+                    context,
+                    filepath=publish_path,
+                    selected=False,
+                    visible_objects_only=True,
+                    uvs=True,
+                    face_sets=True,
+                    start=start_frame,
+                    end=end_frame,
+                )
+               
 
         except Exception as e:
             error_msg = "Failed to export Geometry: %s" % e


### PR DESCRIPTION
In Blender 3.x versions, alembic export was giving an error as the renderable_only was depreciated. This fixes that issues and ensures that the alembic export works with both Blender 2.x and Blender 3.x