### PR TITLE
PySide6 compatibility + new 4.2 modal_operators check in case event dies

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -16,6 +16,7 @@ A Blender engine for Tank.
 https://www.blender.org/
 """
 
+import collections
 import os
 import sys
 import time
@@ -236,7 +237,13 @@ class BlenderEngine(Engine):
         Displays a dialog with the message according to  the severity level
         specified.
         """
-        from sgtk.platform.qt import QtGui, QtCore
+        try:
+            from sgtk.platform.qt import QtGui, QtCore
+        except ImportError:
+            logger.error("Could not import qtgui, qtcore. Called before engine init.")
+            log_level = getattr(logger, level)
+            log_level(msg)
+            return
 
         level_icon = {
             "info": QtGui.QMessageBox.Information,
@@ -330,6 +337,11 @@ class BlenderEngine(Engine):
         utf8 = QtCore.QTextCodec.codecForName("utf-8")
         QtCore.QTextCodec.setCodecForCStrings(utf8)
         self.logger.debug("set utf-8 codec for widget text")
+
+        # MutableMapping has been moved in py310. tk-multi-publish2 uses it
+        # it's faster (and dirtier) to just monkey patch here
+        from collections.abc import MutableMapping
+        collections.MutableMapping = MutableMapping
 
     def init_engine(self):
         """
@@ -508,6 +520,8 @@ class BlenderEngine(Engine):
         app = QtGui.QApplication.instance()
         app.aboutToQuit.connect(self.destroy_engine)
 
+        atexit.register(self.__force_quit_blender)
+
         # Run a series of app instance commands at startup.
         self._run_app_instance_commands()
 
@@ -612,6 +626,14 @@ class BlenderEngine(Engine):
                             known_commands,
                         )
 
+    def __force_quit_blender(self):
+         """
+         This is very dangerous as os._exit(1) force closes everything without any cleanup but as of right now, I can't
+         figure out what the process is waiting for when closing a blender process started through shotgrid
+         """
+         print("Force quitting Blender")
+         os._exit(1)
+         
     def destroy_engine(self):
         """
         Let's close the windows created by the engine before exiting the

--- a/info.yml
+++ b/info.yml
@@ -100,3 +100,6 @@ description: "Shotgun Integration in Blender"
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.18.8"
+
+frameworks:
+    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x"}

--- a/startup.py
+++ b/startup.py
@@ -85,13 +85,13 @@ class BlenderLauncher(SoftwareLauncher):
 
         startup_path = os.path.join(scripts_path, "startup", "Shotgun_menu.py")
 
-        args += "-P " + startup_path
+        args += " -P " + startup_path
 
         required_env["BLENDER_USER_SCRIPTS"] = scripts_path
 
-        if not os.environ.get("PYSIDE2_PYTHONPATH"):
-            pyside2_python_path = os.path.join(self.disk_location, "python", "ext")
-            required_env["PYSIDE2_PYTHONPATH"] = pyside2_python_path
+        if not os.environ.get("PYSIDE_PYTHONPATH"):
+            pyside_python_path = os.path.join(self.disk_location, "python", "ext")
+            required_env["PYSIDE_PYTHONPATH"] = pyside_python_path
 
         # Prepare the launch environment with variables required by the
         # classic bootstrap approach.

--- a/startup/bootstrap.py
+++ b/startup/bootstrap.py
@@ -127,7 +127,7 @@ def start_toolkit():
     # start up toolkit logging to file
     sgtk.LogManager().initialize_base_file_handler(ENGINE_NAME)
 
-    # Rely on the classic boostrapping method
+    # Rely on the classic bootstrapping method
     start_toolkit_classic()
 
     # Check if a file was specified to open and open it.


### PR DESCRIPTION
Some new changes to work with PySide6 and Blender 4.2+.

The QT Event loop was causing seg faults when performing the New File action in tk-multi-workfiles2, as well as some other actions in other apps. To mitigate this, events are processed directly by the app rather than using an event loop. This fixes the crashes.

The event loop was also being killed after new file operations, so I've added a handler for load_post to create the event loop again if it has died. This does use the new window.modal_operators implemented with Blender 4.2 to ensure only one loop exists at a time, which would need to be handled in a different way for pre-4.2 compatibility.

Also includes changes from #18 